### PR TITLE
Added maintenance_info in catalog schema 

### DIFF
--- a/src/main/resources/catalog-schema.json
+++ b/src/main/resources/catalog-schema.json
@@ -90,6 +90,23 @@
                   "type": "string",
                   "pattern": "\\S+"
                 },
+                "maintenance_info": {
+                  "type": "object",
+                  "required": [
+                    "version"
+                  ],
+                  "additionalProperties": true,
+                  "properties": {
+                    "version": {
+                      "type": "string",
+                      "pattern": "^(.*)$"
+                    },
+                    "description": {
+                      "type": "string",
+                      "pattern": "\\S+"
+                    }
+                  }
+                },
                 "name": {
                   "type": "string",
                   "pattern": "^[a-z0-9-]+$"


### PR DESCRIPTION
The  2.15 version of OSBAPI spec defines maintenace_info as part of the service catalog, see [change log here](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#changes-since-v214) and [maintenace_info definition here](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#maintenance-info-object)