### PR TITLE
allow skipping ssl verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ config:
   apiVersion: 2.13
   user: user
   password: password
+  skipTLSVerification: false
 ##The following configuration are Optional
   usingAppGuid: true
 

--- a/src/main/kotlin/de/evoila/osb/checker/config/Configuration.kt
+++ b/src/main/kotlin/de/evoila/osb/checker/config/Configuration.kt
@@ -22,7 +22,7 @@ class Configuration {
   lateinit var wrongUserToken: String
   lateinit var wrongPasswordToken: String
 
-
+  var skipTLSVerification: Boolean = false
   var usingAppGuid: Boolean = true
   val provisionParameters: HashMap<String, HashMap<String, Any>> = hashMapOf()
   val bindingParameters: HashMap<String, HashMap<String, Any>> = hashMapOf()

--- a/src/main/kotlin/de/evoila/osb/checker/config/RestAssureConfig.kt
+++ b/src/main/kotlin/de/evoila/osb/checker/config/RestAssureConfig.kt
@@ -15,6 +15,8 @@ class RestAssureConfig(
 
     RestAssured.baseURI = configuration.url
     RestAssured.port = configuration.port
+    if(configuration.skipTLSVerification){
+      RestAssured.useRelaxedHTTPSValidation()
+    }
   }
-
 }


### PR DESCRIPTION
Some brokers might be configured to use TLS. This is a work to make it possible to skip TLS verification using the configuration file since this is meant to be a testing tool.

The default behaviour still remains the same. 