### PR TITLE
Altering plan and service for conflict Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,5 @@ Changes since v1.0:
  - Too reduce runtime invalid and valid binding tests use the same provision for testing instead.
  
  HotFix: 
-    - swap service id and/or plan id when testing service broker behaviour for conflicting binding. Test wont be executed when, only one plan is listed in the actual catalog.
+    - swap service id and/or plan id, when testing service broker behaviour for conflicting binding. Test wont be executed when, only one plan is listed in the actual catalog.
     (the swap is not influenced by service plans defined in the config)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ config:
   password: password
 ```
 
-Then call `java -jar osb-checker-kotlin-1.0.jar` on the commandline to start checker. In this configuration the checker will run all tests for every service-plan listed 
+Then call `java -jar osb-checker-kotlin-1.1.1.jar` on the commandline to start checker. In this configuration the checker will run all tests for every service-plan listed 
 in the catalog. See the chapter [Usage](docs/Usage.md) for more details about configuring this test-application.
 
 ## Changes
@@ -73,4 +73,5 @@ Changes since v1.0:
  - Too reduce runtime invalid and valid binding tests use the same provision for testing instead.
  
  HotFix: 
-    - altering paramters instead of planId when testing service broker behaviour for conflicting binding.
+    - swap service id and/or plan id when testing service broker behaviour for conflicting binding. Test wont be executed when, only one plan is listed in the actual catalog.
+    (the swap is not influenced by service plans defined in the config)

--- a/docs/BindingTests.md
+++ b/docs/BindingTests.md
@@ -90,7 +90,7 @@ A Binding Test output with two services. 'base-sql-service-dev-managed' is binda
          │  │  └─ Running PUT binding and DELETE binding afterwards ✔
          │  │     ├─ Running valid PUT binding with bindingId 27285fe4-c124-4a22-85be-f6db91de8373 ✔
          │  │     ├─ Running PUT binding with same attribute again. Expecting StatusCode 200. ✔
-         │  │     ├─ Running PUT binding with different attribute again. Expecting StatusCode 409. ✔
+         │  │     ├─ Running PUT binding with different service or plan id, but same instance and binding id again. Expecting StatusCode 409. ✔
          │  │     ├─ Running GET for retrievable service binding and expecting StatusCode: 200 ✔
          │  │     └─ Deleting binding with bindingId 27285fe4-c124-4a22-85be-f6db91de8373 ✔
          │  └─ Deleting provision ✔

--- a/src/main/kotlin/de/evoila/osb/checker/util/MyTreePrinter.kt
+++ b/src/main/kotlin/de/evoila/osb/checker/util/MyTreePrinter.kt
@@ -9,129 +9,149 @@ import org.junit.platform.engine.reporting.ReportEntry
 import java.io.PrintWriter
 
 class MyTreePrinter(
-    private val theme: Theme,
-    private val out: PrintWriter
+        private val theme: Theme,
+        private val out: PrintWriter
 ) {
 
-  fun print(node: TreeNode) {
-    out.println(color(Color.CONTAINER, theme.root()))
-    print(node, "", true)
-    out.flush()
-  }
-
-  private fun print(node: TreeNode, indent: String, continuous: Boolean) {
-    var varIndent = indent
-    if (node.visible) {
-      printVisible(node, varIndent, continuous)
-    }
-    if (node.children.isEmpty()) {
-      return
-    }
-    if (node.visible) {
-      varIndent += if (continuous) theme.vertical() else theme.blank()
-    }
-    val iterator = node.children.iterator()
-    while (iterator.hasNext()) {
-      print(iterator.next(), varIndent, iterator.hasNext())
-    }
-  }
-
-  private fun printVisible(node: TreeNode, indent: String, continuous: Boolean) {
-    val bullet = if (continuous) theme.entry() else theme.end()
-    val prefix = color(Color.CONTAINER, indent + bullet)
-    val tabbed = color(Color.CONTAINER, indent + (if (continuous) theme.vertical() else theme.blank()) + theme.blank())
-    val caption = colorCaption(node)
-    val duration = color(Color.CONTAINER, node.duration.toString() + " ms")
-    var icon = color(SKIPPED, theme.skipped())
-
-    node.result?.let {
-      val resultColor = Color.valueOf(it)
-      icon = color(resultColor, theme.status(it))
-
+    fun print(node: TreeNode) {
+        out.println(color(Color.CONTAINER, theme.root()))
+        print(node, "", true)
+        out.flush()
     }
 
-    out.print(prefix)
-    out.print(" ")
-    out.print(caption)
-
-    if (node.duration > 10000 && node.children.isEmpty()) {
-      out.print(" ")
-      out.print(duration)
+    private fun print(node: TreeNode, indent: String, continuous: Boolean) {
+        var varIndent = indent
+        if (node.visible) {
+            printVisible(node, varIndent, continuous)
+        }
+        if (node.children.isEmpty()) {
+            return
+        }
+        if (node.visible) {
+            varIndent += if (continuous) theme.vertical() else theme.blank()
+        }
+        val iterator = node.children.iterator()
+        while (iterator.hasNext()) {
+            print(iterator.next(), varIndent, iterator.hasNext())
+        }
     }
 
-    out.print(" ")
-    out.print(icon)
-    node.result?.let { result -> printThrowable(tabbed, result) }
-    node.reason?.let { reason -> printMessage(SKIPPED, tabbed, reason) }
-    node.reports.forEach { e -> printReportEntry(tabbed, e) }
-    out.println()
-  }
+    private fun printVisible(node: TreeNode, indent: String, continuous: Boolean) {
+        val bullet = if (continuous) theme.entry() else theme.end()
+        val prefix = color(Color.CONTAINER, indent + bullet)
+        val tabbed = color(Color.CONTAINER, indent + (if (continuous) theme.vertical() else theme.blank()) + theme.blank())
+        val duration = color(Color.CONTAINER, node.duration.toString() + " ms")
+        var icon = color(SKIPPED, theme.skipped())
 
-  private fun colorCaption(node: TreeNode): String {
-    val caption = node.caption
+        val caption = if (skippedDynamicTest(node)) {
+            color(SKIPPED, node.caption).replace("%SKIPPED%", "")
+        } else {
+            node.result?.let {
+                val resultColor = Color.valueOf(it)
+                icon = color(resultColor, theme.status(it))
+            }
+            colorCaption(node)
+        }
 
-    node.result?.let {
-      val resultColor = Color.valueOf(it)
-      if (it.status != Status.SUCCESSFUL) {
-        return color(resultColor, caption)
-      }
+        out.print(prefix)
+        out.print(" ")
+        out.print(caption)
+
+        if (node.duration > 10000 && node.children.isEmpty()) {
+            out.print(" ")
+            out.print(duration)
+        }
+
+        out.print(" ")
+        out.print(icon)
+        node.result?.let { result -> printThrowable(tabbed, result) }
+        node.reason?.let { reason -> printMessage(SKIPPED, tabbed, reason) }
+        node.reports.forEach { e -> printReportEntry(tabbed, e) }
+        out.println()
     }
 
-    return node.reason?.let {
-      color(SKIPPED, caption)
-    } ?: color(Color.valueOf(node.identifier!!), caption)
-
-
-  }
-
-  private fun printThrowable(indent: String, result: TestExecutionResult) {
-    if (!result.throwable.isPresent) {
-      return
+    /*
+     * Dynamic tests are NOT skippable. However, to log that a certain test has not been created, I added the possibility
+     * to create a DynamicTest with the Tag %SKIPPED% in the DisplayName, that this TreePrinter will recognize inorder to
+     * log a skipped test. The JUnit5 suit itself, will NOT consider the test as skipped. Only this TreePrinter will use.
+     *
+     * Create a dynamic test with an empty bock like this
+     * Usage: DynamicTest("%SKIPPED%This test got skipped, because of reasons"){}
+     * To take advantage of it.
+     *
+     * it will be logged by the TreePrinter like:
+     *   ├─ This test got skipped, because of reasons. ↷
+     *
+     */
+    private fun skippedDynamicTest(node: TreeNode): Boolean {
+        return node.caption.contains("%SKIPPED%")
     }
-    val throwable = result.throwable.get()
-    val message = throwable.message ?: throwable.toString()
 
-    printMessage(Color.FAILED, indent, message)
-  }
+    private fun colorCaption(node: TreeNode): String {
+        val caption = node.caption
 
-  private fun printReportEntry(indent: String, reportEntry: ReportEntry) {
-    out.println()
-    out.print(indent)
-    out.print(reportEntry.timestamp)
-    val entries = reportEntry.keyValuePairs.entries
-    if (entries.size == 1) {
-      printReportEntry(" ", getOnlyElement(entries))
-      return
+        node.result?.let {
+            val resultColor = Color.valueOf(it)
+            if (it.status != Status.SUCCESSFUL) {
+                return color(resultColor, caption)
+            }
+        }
+
+        return node.reason?.let {
+            color(SKIPPED, caption)
+        } ?: color(Color.valueOf(node.identifier!!), caption)
+
+
     }
-    for (entry in entries) {
-      out.println()
-      printReportEntry(indent + theme.blank(), entry)
+
+    private fun printThrowable(indent: String, result: TestExecutionResult) {
+        if (!result.throwable.isPresent) {
+            return
+        }
+        val throwable = result.throwable.get()
+        val message = throwable.message ?: throwable.toString()
+
+        printMessage(Color.FAILED, indent, message)
     }
-  }
 
-  private fun printReportEntry(indent: String, mapEntry: Map.Entry<String, String>) {
-    out.print(indent)
-    out.print(color(Color.YELLOW, mapEntry.key))
-    out.print(" = `")
-    out.print(color(Color.GREEN, mapEntry.value))
-    out.print("`")
-  }
-
-  private fun printMessage(color: Color, indent: String, message: String) {
-    val lines = message.split("\\R".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-    out.print(" ")
-    out.print(color(color, lines[0]))
-    if (lines.size > 1) {
-      for (i in 1 until lines.size) {
+    private fun printReportEntry(indent: String, reportEntry: ReportEntry) {
         out.println()
         out.print(indent)
-        if (StringUtils.isNotBlank(lines[i])) {
-          val extra = theme.blank()
-          out.print(color(color, extra + lines[i]))
+        out.print(reportEntry.timestamp)
+        val entries = reportEntry.keyValuePairs.entries
+        if (entries.size == 1) {
+            printReportEntry(" ", getOnlyElement(entries))
+            return
         }
-      }
+        for (entry in entries) {
+            out.println()
+            printReportEntry(indent + theme.blank(), entry)
+        }
     }
-  }
 
-  fun color(color: Color, text: String) = "$color$text${Color.NONE}"
+    private fun printReportEntry(indent: String, mapEntry: Map.Entry<String, String>) {
+        out.print(indent)
+        out.print(color(Color.YELLOW, mapEntry.key))
+        out.print(" = `")
+        out.print(color(Color.GREEN, mapEntry.value))
+        out.print("`")
+    }
+
+    private fun printMessage(color: Color, indent: String, message: String) {
+        val lines = message.split("\\R".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        out.print(" ")
+        out.print(color(color, lines[0]))
+        if (lines.size > 1) {
+            for (i in 1 until lines.size) {
+                out.println()
+                out.print(indent)
+                if (StringUtils.isNotBlank(lines[i])) {
+                    val extra = theme.blank()
+                    out.print(color(color, extra + lines[i]))
+                }
+            }
+        }
+    }
+
+    fun color(color: Color, text: String) = "$color$text${Color.NONE}"
 }

--- a/src/main/kotlin/de/evoila/osb/checker/util/TreeNode.kt
+++ b/src/main/kotlin/de/evoila/osb/checker/util/TreeNode.kt
@@ -5,53 +5,54 @@ import org.junit.platform.engine.reporting.ReportEntry
 import org.junit.platform.launcher.TestIdentifier
 import java.util.*
 
-class TreeNode(val caption: String,
-               val creation: Long = System.currentTimeMillis(),
-               var duration: Long = 0,
-               val reason: String? = null,
-               val identifier: TestIdentifier? = null,
-               var result: TestExecutionResult? = null,
-               var reports: MutableList<ReportEntry> = mutableListOf(),
-               var children: MutableList<TreeNode> = mutableListOf(),
-               var visible: Boolean
+class TreeNode(
+        val caption: String,
+        val creation: Long = System.currentTimeMillis(),
+        var duration: Long = 0,
+        val reason: String? = null,
+        val identifier: TestIdentifier? = null,
+        var result: TestExecutionResult? = null,
+        var reports: MutableList<ReportEntry> = mutableListOf(),
+        var children: MutableList<TreeNode> = mutableListOf(),
+        var visible: Boolean
 ) {
 
-  constructor(caption: String) : this(
-      caption = caption,
-      visible = false
-  )
+    constructor(caption: String) : this(
+            caption = caption,
+            visible = false
+    )
 
 
-  constructor(testIdentifier: TestIdentifier) : this(
-      caption = testIdentifier.displayName,
-      identifier = testIdentifier,
-      visible = true
-  )
+    constructor(testIdentifier: TestIdentifier) : this(
+            caption = testIdentifier.displayName,
+            identifier = testIdentifier,
+            visible = true
+    )
 
-  constructor(testIdentifier: TestIdentifier, reason: String) : this(
-      caption = testIdentifier.displayName,
-      identifier = testIdentifier,
-      visible = true,
-      reason = reason
-  )
+    constructor(testIdentifier: TestIdentifier, reason: String) : this(
+            caption = testIdentifier.displayName,
+            identifier = testIdentifier,
+            visible = true,
+            reason = reason
+    )
 
-  fun addChild(node: TreeNode): TreeNode {
-    if (children === Collections.EMPTY_LIST) {
-      children = ArrayList()
+    fun addChild(node: TreeNode): TreeNode {
+        if (children === Collections.EMPTY_LIST) {
+            children = ArrayList()
+        }
+
+        children.add(node)
+        return this
     }
 
-    children.add(node)
-    return this
-  }
+    fun addReportEntry(reportEntry: ReportEntry): TreeNode {
+        reports.add(reportEntry)
+        return this
+    }
 
-  fun addReportEntry(reportEntry: ReportEntry): TreeNode {
-    reports.add(reportEntry)
-    return this
-  }
-
-  fun setResult(result: TestExecutionResult): TreeNode {
-    this.result = result
-    this.duration = System.currentTimeMillis() - creation
-    return this
-  }
+    fun setResult(result: TestExecutionResult): TreeNode {
+        this.result = result
+        this.duration = System.currentTimeMillis() - creation
+        return this
+    }
 }

--- a/src/main/kotlin/de/evoila/osb/checker/util/TreeNode.kt
+++ b/src/main/kotlin/de/evoila/osb/checker/util/TreeNode.kt
@@ -37,9 +37,6 @@ class TreeNode(
     )
 
     fun addChild(node: TreeNode): TreeNode {
-        if (children === Collections.EMPTY_LIST) {
-            children = ArrayList()
-        }
 
         children.add(node)
         return this

--- a/src/main/resources/catalog-schema.json
+++ b/src/main/resources/catalog-schema.json
@@ -133,6 +133,9 @@
                 "free": {
                   "type": "boolean"
                 },
+                "plan_updateable": {
+                  "type": "boolean"
+                },
                 "bindable": {
                   "type": "boolean"
                 },


### PR DESCRIPTION
Instead of editing the parameter field, the plan and service id will be exchanged with others from the catalog to test a conflict case when attempting to call PUT binding.

