### PR TITLE
Feat/test binding on nonexisting service instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,5 @@ Changes since v1.0:
  - Too reduce runtime invalid and valid binding tests use the same provision for testing instead.
  
  HotFix: 
-    - swap service id and/or plan id, when testing service broker behaviour for conflicting binding. Test wont be executed when, only one plan is listed in the actual catalog.
+    - swap service id and/or plan id, when testing service broker behaviour for conflicting binding. Test wont be executed, if only one plan is listed in the actual catalog.
     (the swap is not influenced by service plans defined in the config)

--- a/docs/BindingTests.md
+++ b/docs/BindingTests.md
@@ -39,6 +39,9 @@ service instances don't work, so it is recommended that the [provision tests](Pr
 
 At the beginning of a test the catalog is fetched. The checker then runs the following tests based upon the provided information:
 
+- Bindings on non existing Service Instances
+    - runs only on bindable services
+        - tests that the service broker returns 4XX when trying to call PUT, DELETE and GET (if fetchable) bindings on non existing service instances.
 - Valid Provision and Bindings
     - Create a valid provision.
         - If the Service broker creates service instances asynchronously, the checker will start polling and and verify the responses.
@@ -71,6 +74,11 @@ A Binding Test output with two services. 'base-sql-service-dev-managed' is binda
 ╷
 └─ JUnit Jupiter ✔
    └─ Binding Tests ✔
+      ├─ PUT and DELETE and possibly GET bindings requests with non existing service instance Id. Expecting a 4XX Error Code ✔
+      │  └─ Testing service b1f8fa45-d58d-40a2-9797-be2da2136a25 plan cad65d27-bfc6-4359-b039-3799c28b082d ✔
+      │     ├─ Testing PUT binding ✔
+      │     ├─ Testing DELETE binding ✔
+      │     └─ Testing GET binding. ✔   
       └─ Valid Provision and Binding Tests. ✔
          ├─ Running a valid provision and run binding tests. Delete both afterwards. In case of a asynchronous service broker polling after each operation. ✔
          │  ├─ Creating Service Instance, test dashboard URL, and try to fetch it. ✔
@@ -101,6 +109,7 @@ A Binding Test output with two services. 'base-sql-service-dev-managed' is binda
             │  ├─ Running valid PUT provision with instanceId a408b58d-aa4b-4c53-b851-f3d331cdfe43 for service 'base-sql-service-dev-unmanaged' and plan 's' ✔
             │  ├─ Running valid PUT provision with same attributes again. Expecting Status 200. ✔
             │  └─ Running valid PUT provision with different attributes again. Expecting Status 409. ✔
+            ├─ Service 'base-sql-service-dev-unmanaged' Plan s is not bindable. Skipping binding tests. ↷
             └─ Deleting provision ✔
                ├─ DELETE provision and if the service broker is async polling afterwards ✔
                └─ Running valid DELETE provision with same parameters again. Expecting Status 410. ✔

--- a/src/main/kotlin/de/evoila/osb/checker/tests/BindingJUnit5.kt
+++ b/src/main/kotlin/de/evoila/osb/checker/tests/BindingJUnit5.kt
@@ -1,8 +1,7 @@
 package de.evoila.osb.checker.tests
 
 import de.evoila.osb.checker.request.BindingRequestRunner
-import de.evoila.osb.checker.request.ResponseBodyType.ERR
-import de.evoila.osb.checker.request.ResponseBodyType.VALID_BINDING
+import de.evoila.osb.checker.request.ResponseBodyType.*
 import de.evoila.osb.checker.request.bodies.BindingBody
 import de.evoila.osb.checker.request.bodies.ProvisionBody
 import de.evoila.osb.checker.response.catalog.Plan
@@ -55,7 +54,7 @@ class BindingJUnit5 : TestBase() {
                         binding.parameters = it[plan.id]
                     }
                 }
-                val dynamicContainers = mutableListOf(
+                val dynamicContainers: MutableList<DynamicNode> = mutableListOf(
                         bindingContainerFactory.validProvisionContainer(
                                 instanceId = instanceId,
                                 plan = plan,
@@ -79,6 +78,8 @@ class BindingJUnit5 : TestBase() {
                                     plan = plan
                             ))
                     ))
+                } else {
+                    dynamicContainers.add(dynamicTest("%SKIPPED%Service ${service.name} Plan ${plan.name} is not bindable. Skipping binding tests.") {})
                 }
 
                 dynamicContainers.add(bindingContainerFactory.validDeleteProvisionContainer(instanceId, service, plan))
@@ -161,6 +162,60 @@ class BindingJUnit5 : TestBase() {
         })
         return dynamicContainer("Run sync and invalid bindings attempts", bindingTests)
     }
+
+    @TestFactory
+    @DisplayName("PUT and DELETE and possibly GET bindings requests with non existing service instance Id. Expecting a 4XX Error Code ")
+    fun testBindingOnNonExistingServiceInstance(): List<DynamicNode> {
+        val invalidServiceInstanceId = UUID.randomUUID().toString()
+        val bindingId = UUID.randomUUID().toString()
+
+        return configuration.initCustomCatalog(catalogRequestRunner.correctRequest()).services.flatMap { service ->
+            service.plans.filter { plan -> planIsBindable(service, plan) }.map { bindablePlan ->
+                val binding = if (needAppGUID(bindablePlan)) BindingBody(
+                        serviceId = service.id,
+                        planId = bindablePlan.id,
+                        appGuid = UUID.randomUUID().toString()
+                )
+                else BindingBody(serviceId = service.id, planId = bindablePlan.id)
+
+                configuration.bindingParameters.let {
+                    if (it.containsKey(bindablePlan.id)) {
+                        binding.parameters = it[bindablePlan.id]
+                    }
+                }
+                dynamicContainer("Testing service ${service.id} plan ${bindablePlan.id}", listOf(
+                        dynamicTest("Testing PUT binding") {
+                            bindingRequestRunner.runPutBindingRequestAsync(
+                                    requestBody = binding,
+                                    instanceId = invalidServiceInstanceId,
+                                    bindingId = bindingId,
+                                    expectedStatusCodes = *IntArray(100) { 400 + it },
+                                    expectedResponseBody = NO_SCHEMA
+                            )
+                        },
+                        dynamicTest("Testing DELETE binding") {
+                            bindingRequestRunner.runDeleteBindingRequestAsync(
+                                    serviceId = binding.serviceId,
+                                    planId = binding.planId,
+                                    instanceId = invalidServiceInstanceId,
+                                    bindingId = bindingId,
+                                    expectedStatusCodes = *IntArray(100) { 400 + it }
+                            )
+                        },
+                        if (service.bindingsRetrievable == true) {
+                            dynamicTest("Testing GET binding.") {
+                                bindingRequestRunner.runGetBindingRequest(
+                                        instanceId = invalidServiceInstanceId,
+                                        bindingId = bindingId,
+                                        expectedStatusCodes = *IntArray(100) { 400 + it }
+                                )
+                            }
+                        } else dynamicTest("%SKIPPED%Binding is not retrievable. Skipping GET binding.") {}
+                ))
+            }
+        }
+    }
+
 
     private fun planIsBindable(service: Service, plan: Plan): Boolean = plan.bindable ?: service.bindable
 

--- a/src/main/kotlin/de/evoila/osb/checker/tests/BindingJUnit5.kt
+++ b/src/main/kotlin/de/evoila/osb/checker/tests/BindingJUnit5.kt
@@ -79,7 +79,7 @@ class BindingJUnit5 : TestBase() {
                             ))
                     ))
                 } else {
-                    dynamicContainers.add(dynamicTest("%SKIPPED%Service ${service.name} Plan ${plan.name} is not bindable. Skipping binding tests.") {})
+                    dynamicContainers.add(dynamicTest("%SKIPPED%Service '${service.name}' Plan ${plan.name} is not bindable. Skipping binding tests.") {})
                 }
 
                 dynamicContainers.add(bindingContainerFactory.validDeleteProvisionContainer(instanceId, service, plan))


### PR DESCRIPTION
Add test that: 
runs PUT, DELETE and GET binding, with a service instance id that leads nowhere.
Asserts that 4XX gets returned.