### PR TITLE
Send auth information on first request

### DIFF
--- a/src/main/kotlin/de/evoila/osb/checker/request/BindingRequestRunner.kt
+++ b/src/main/kotlin/de/evoila/osb/checker/request/BindingRequestRunner.kt
@@ -187,7 +187,7 @@ class BindingRequestRunner(configuration: Configuration) : PollingRequestHandler
     fun putWithoutHeader() {
         RestAssured.with()
                 .log().ifValidationFails()
-                .auth().basic(configuration.user, configuration.password)
+                .auth().preemptive().basic(configuration.user, configuration.password)
                 .put(SERVICE_INSTANCE_PATH + Configuration.notAnId + SERVICE_BINDING_PATH + Configuration.notAnId)
                 .then()
                 .log().ifValidationFails()
@@ -198,7 +198,7 @@ class BindingRequestRunner(configuration: Configuration) : PollingRequestHandler
     fun deleteWithoutHeader() {
         RestAssured.with()
                 .log().ifValidationFails()
-                .auth().basic(configuration.user, configuration.password)
+                .auth().preemptive().basic(configuration.user, configuration.password)
                 .put(SERVICE_INSTANCE_PATH + Configuration.notAnId + SERVICE_BINDING_PATH + Configuration.notAnId)
                 .then()
                 .log().ifValidationFails()

--- a/src/main/kotlin/de/evoila/osb/checker/request/CatalogRequestRunner.kt
+++ b/src/main/kotlin/de/evoila/osb/checker/request/CatalogRequestRunner.kt
@@ -16,7 +16,7 @@ class CatalogRequestRunner(
     fun withoutHeader() {
         RestAssured.with()
                 .log().ifValidationFails()
-                .auth().basic(configuration.user, configuration.password)
+                .auth().preemptive().basic(configuration.user, configuration.password)
                 .get("/v2/catalog")
                 .then()
                 .log().ifValidationFails()
@@ -32,7 +32,7 @@ class CatalogRequestRunner(
         RestAssured.with()
                 .log().ifValidationFails()
                 .headers(validRequestHeaders)
-                .auth().basic(configuration.user, configuration.password)
+                .auth().preemptive().basic(configuration.user, configuration.password)
                 .get("/v2/catalog")
                 .then()
                 .log().ifValidationFails()

--- a/src/main/kotlin/de/evoila/osb/checker/request/ProvisionRequestRunner.kt
+++ b/src/main/kotlin/de/evoila/osb/checker/request/ProvisionRequestRunner.kt
@@ -175,7 +175,7 @@ class ProvisionRequestRunner(configuration: Configuration) : PollingRequestHandl
     fun putWithoutHeader() {
         RestAssured.with()
                 .log().ifValidationFails()
-                .auth().basic(configuration.user, configuration.password)
+                .auth().preemptive().basic(configuration.user, configuration.password)
                 .put(SERVICE_INSTANCE_PATH + Configuration.notAnId + ACCEPTS_INCOMPLETE)
                 .then()
                 .log().ifValidationFails()
@@ -186,7 +186,7 @@ class ProvisionRequestRunner(configuration: Configuration) : PollingRequestHandl
     fun deleteWithoutHeader() {
         RestAssured.with()
                 .log().ifValidationFails()
-                .auth().basic(configuration.user, configuration.password)
+                .auth().preemptive().basic(configuration.user, configuration.password)
                 .delete("$SERVICE_INSTANCE_PATH${Configuration.notAnId}$ACCEPTS_INCOMPLETE&service_id=Invalid&plan_id=Invalid")
                 .then()
                 .log().ifValidationFails()
@@ -197,7 +197,7 @@ class ProvisionRequestRunner(configuration: Configuration) : PollingRequestHandl
     fun lastOperationWithoutHeader() {
         RestAssured.with()
                 .log().ifValidationFails()
-                .auth().basic(configuration.user, configuration.password)
+                .auth().preemptive().basic(configuration.user, configuration.password)
                 .get(SERVICE_INSTANCE_PATH + Configuration.notAnId + LAST_OPERATION)
                 .then()
                 .log().ifValidationFails()


### PR DESCRIPTION
As per the [RestAssured docs](https://github.com/rest-assured/rest-assured/wiki/Usage#preemptive-basic-authentication), we can use _preemptive basic authentication_:
```
This will send the basic authentication credential even before the server gives an unauthorized response in certain situations, thus reducing the overhead of making an additional connection. This is typically what you want to use in most situations unless you're testing the servers ability to challenge.
```

This will fix the issue raised in #30 

What do you think?


fixes #30 