### PR TITLE
Fix AuthenticationJUnit5 sending wrong api header

### DIFF
--- a/src/main/kotlin/de/evoila/osb/checker/request/BindingRequestRunner.kt
+++ b/src/main/kotlin/de/evoila/osb/checker/request/BindingRequestRunner.kt
@@ -221,7 +221,7 @@ class BindingRequestRunner(configuration: Configuration) : PollingRequestHandler
         RestAssured.with()
                 .header(Header("Authorization", wrongUsernameToken))
                 .log().ifValidationFails()
-                .header(Header("X-Broker-API-Version", "$configuration.apiVersion"))
+                .header(Header("X-Broker-API-Version", "${configuration.apiVersion}"))
                 .put(SERVICE_INSTANCE_PATH + Configuration.notAnId + SERVICE_BINDING_PATH + Configuration.notAnId)
                 .then()
                 .log().ifValidationFails()


### PR DESCRIPTION
BindingRequestRunner#putWrongUser has no other usages.

Expected Headers:
```
  Authorization=Basic ZDViNzBhY2UtZTU3Zi00MWNjLWI3YjMtZTUyNDA0MmFmNTZhOnBhc3N3b3Jk
  X-Broker-API-Version=2.15
  Accept=*/*
```
Actual Headers:
```
  Authorization=Basic ZDViNzBhY2UtZTU3Zi00MWNjLWI3YjMtZTUyNDA0MmFmNTZhOnBhc3N3b3Jk
  X-Broker-API-Version=de.evoila.osb.checker.config.Configuration@1fc32e4f.apiVersion
  Accept=*/*
```